### PR TITLE
bug fixed en vacaciones editar

### DIFF
--- a/client/src/app/modules/applications/pages/edit/components/vacation/vacation.component.ts
+++ b/client/src/app/modules/applications/pages/edit/components/vacation/vacation.component.ts
@@ -170,6 +170,7 @@ export class VacationComponent implements OnInit {
           start_working_date: data.vacation.start_working_date,
           end_working_date: data.vacation.end_working_date,
         });
+
         let status_app =
           data.application_status[data.application_status.length - 1].status
             .name;
@@ -210,13 +211,6 @@ export class VacationComponent implements OnInit {
   // ------------ SUBMIT FORM  ------------
   // --------------------------------------
   submit() {
-    this.submitted = true;
-
-    // Se detiene aqui si el formulario es invalido
-    if (this.form.invalid) {
-      return;
-    }
-
     const isWorkingDaysSet = this.form.get('total_working_days')?.value === 0;
     const isCalendarDaysSet = this.form.get('total_calendar_days')?.value === 0;
 

--- a/client/src/app/shared/components/date-picker-range/date-picker-range.component.ts
+++ b/client/src/app/shared/components/date-picker-range/date-picker-range.component.ts
@@ -26,7 +26,6 @@ import { LaboralDays } from '@shared/utils';
   styleUrls: ['./date-picker-range.component.scss'],
 })
 export class DatePickerRangeComponent implements OnInit, OnChanges {
-  
   @Input() default_date_picker: any;
   @Input() total_days: any;
   @Input() laboralflag: boolean = true;
@@ -67,7 +66,14 @@ export class DatePickerRangeComponent implements OnInit, OnChanges {
     });
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    if (this.total_days === 0) {
+      this.form.patchValue({
+        start_date: null,
+        end_date: null,
+      });
+    }
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (this.initStartDate && this.initEndDate) {


### PR DESCRIPTION
Se arregla el bug de vacaciones editar que impedia el actualizado de la solicitud por el hecho de tener un tipo de vacaciones vacio.

Se elimina la siguiente validación para que permita actualizar la solicitud dado el caso posible planteado de no tener que poner extrictamente los dos tipos de días 'calendario' y 'hábiles' en la misma solicitud.

`if (this.form.invalid) {
      return;
 }
`
**Nota:** El hecho de que se haya eliminado esa sección de código no implica que no se estén haciendo las validaciones necesarias, eso se tuvo en cuenta y se codificó desde la creación del date picker. 

