### PR TITLE
:bug: Botón actualizar en edit vacation no funcionaba

### DIFF
--- a/client/src/app/modules/applications/pages/edit/components/vacation/vacation.component.ts
+++ b/client/src/app/modules/applications/pages/edit/components/vacation/vacation.component.ts
@@ -212,10 +212,13 @@ export class VacationComponent implements OnInit {
   // --------------------------------------
 
   coherenceDaysValidation(
-    start_day: Date,
-    end_day: Date,
+    start_day: Date | string,
+    end_day: Date | string,
     isWorkingDays: boolean
   ) {
+    start_day = new Date(start_day);
+    end_day = new Date(end_day);
+
     if (isWorkingDays) {
       const calcWorkingDays = end_day.getDate() - start_day.getDate() + 1;
       const totalWorkingDays = this.form.get('total_working_days')?.value;


### PR DESCRIPTION
Decía ERROR TypeError: end_day.getDate is not a function coherenceDaysValidation. Copilot concluyó que de alguna forma end_day no tenía formato Date y lo arregló añadiendo estas lineas.